### PR TITLE
ci: add PR CI workflow for PR lint and test

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -31,6 +31,9 @@ jobs:
  
       - name: Install dependencies
         run: pnpm install
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
  
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,39 @@
+name: PR CI
+
+permissions:
+  contents: read
+ 
+on:
+  pull_request:
+
+concurrency:
+  group: pr-ci-${{ github.head_ref }}
+  cancel-in-progress: true
+ 
+jobs:
+  lint-and-test:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+ 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+ 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+ 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+ 
+      - name: Install dependencies
+        run: pnpm install
+ 
+      - name: Lint
+        run: pnpm lint
+ 
+      - name: Test
+        run: pnpm test


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run lint and test, with caching, concurrency, and least privilege.